### PR TITLE
Ajoute une définition de la réstriction d'une fonction

### DIFF
--- a/ensembles/ch_ensembles.tex
+++ b/ensembles/ch_ensembles.tex
@@ -332,6 +332,14 @@ si pour tout $x \in E$, $f(x)=g(x)$. On note alors $f=g$.
          \draw (E) edge[myred, bend right] node[below]{$g\circ f$} (G);
       \end{tikzpicture}
     $$
+    
+     \item \defi{Restriction}\index{restriction}. Soient $f : E \to F$ et $A\subset E$ alors la restriction de $f$ à $A$ est l'application 
+$$\begin {array}{rccc}
+f |_A\ : \ & A &\longrightarrow& F \\
+        &x & \longmapsto & f(x)\\
+\end{array}$$
+ 
+ 
 \end{itemize}
 
 


### PR DESCRIPTION
 avec la notation utilisés dans le ch_fonctions.
Triviale mais mérite d'être introduite explicitement quelque part, ici semble l'endroit adapté.