### PR TITLE
FPV série d'exercices 1 : correction solution exercice 12 question 3

### DIFF
--- a/fpv/exercices/exercices-fpv-1.tex
+++ b/fpv/exercices/exercices-fpv-1.tex
@@ -1293,7 +1293,7 @@ Toutes les fonctions sont continues là où elles sont définies par leur expres
 	
 	\item On remarque que $x^4+y^6 \ge x^4$ donc $|f(x,y)| \le \left| \frac{x^4y}{x^4} \right| = |y|$. Comme $|y| \to 0$, alors $f(x,y) \to f(0,0)=0$ lorsque $(x,y) \to (0,0)$ et $f$ est continue à l'origine.
 		
-	\item Soit $\gamma(t) = (t^2,t)$ (avec $t>0$) alors $f(t^2,t) = \frac{t^5}{t^8+t^6} \sim \frac{t^5}{t^6} \sim \frac{1}{t}$ qui tend vers $+\infty$ lorsque $t\to 0^+$. Ainsi $f(x,y)$ ne peut pas tendre $f(0,0)=0$. Donc $f$ n'est pas continue à l'origine.
+	\item Soit $\gamma(t) = (t^2,t)$, alors $f(t^2,t) = \frac{t^6}{t^8+t^6} \sim \frac{t^6}{t^6} \sim 1$ qui tend vers $1$ lorsque $t \to 0$. Ainsi $f(x,y)$ ne peut pas tendre vers $f(0,0)=0$. Donc $f$ n'est pas continue à l'origine.
 	
 	\item Pour $y\neq 0$, $| f(x,y) | \le y^2$. Donc lorsque $(x,y) \to (x_0,0)$, on a $f(x,y) \to 0$. Donc $f$ est continue en tout point de la forme $(x_0,0)$. Ainsi $f$ est continue sur $\Rr^2$.
 	


### PR DESCRIPTION
Dans la feuille d'exercices 1 FPV (Fonctions à Plusieurs Variables) il y a une **erreur dans la solution de la question 3 de l'exercice 12**: on devrait avoir t^6 au numérateur et non t^5, ce qui change la limite qui passe de  (+infini) à 1. La conclusion ne change pas, la fonction n'est pas continue.

Correction du fichier tex seulement. 

Problème en question dans le PDF : 

**Consigne exercice**
<img width="1121" height="88" alt="exo12_question" src="https://github.com/user-attachments/assets/1edb951c-0a0b-4cdf-bea6-230f15fc2b0c" />
 **Fonction**
<img width="1097" height="121" alt="exo12_fonction" src="https://github.com/user-attachments/assets/3d837281-b605-4314-9fa6-e65051c8b255" />
 **Solution**
<img width="1070" height="92" alt="exo12_solution" src="https://github.com/user-attachments/assets/4d4d5674-d33e-43fc-95ae-88cb5a5fec5c" />